### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+    simplecov-html (0.12.3)
     test-unit (3.3.6)
       power_assert
     yard (0.9.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
This PR makes `bundle install && rake test` succeed on Ruby 3.0.