### PR TITLE
CI: Avoid double bundle install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.4, 2.5, 2.6, 2.7, "3.0"] # Quote "3.0" to avoid 3.0 becoming "3".
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # 'bundle install' and cache
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
This PR avoids double `bundle install` from happening.

Also: add comments.

---

This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849