### PR TITLE
Fix select scope check

### DIFF
--- a/lib/gammo/parser.rb
+++ b/lib/gammo/parser.rb
@@ -234,7 +234,7 @@ module Gammo
           when TABLE_SCOPE
             return -1 if tag == Tags::Html || tag == Tags::Table || tag == Tags::Template
           when SELECT_SCOPE
-            return -1 if tag == Tags::Optgroup && tag == Tags::Option
+            return -1 if tag == Tags::Optgroup || tag == Tags::Option
           else
             raise ParseError, 'unreachable parsing error, please report to github'
           end

--- a/test/select_scope_test.rb
+++ b/test/select_scope_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class SelectScopeTest < Test::Unit::TestCase
+  include Support::Dump
+
+  test 'option and optgroup nesting' do
+    html = '<select><option>One<optgroup><option>Two</option></optgroup></select>'
+    doc = Gammo.new(html).parse
+    assert_equal(<<~OUT, dump_for(doc))
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <option>
+|         "One"
+|       <optgroup>
+|         <option>
+|           "Two"
+    OUT
+    )
+  end
+end
+


### PR DESCRIPTION
## Summary
- fix the condition for SELECT_SCOPE in `Parser#index_of_element_in_scope`
- add regression test for option/optgroup processing

## Testing
- `bundle exec rake test` *(fails: Could not find yard-0.9.25, rake-12.3.3, test-unit-3.3.6, erubi-1.9.0, racc-1.5.0, simplecov-0.18.5, power_assert-1.2.0, docile-1.3.2, simplecov-html-0.12.3 in locally installed gems)*